### PR TITLE
Add custom properties

### DIFF
--- a/gym_jsbsim/catalogs/property.py
+++ b/gym_jsbsim/catalogs/property.py
@@ -7,6 +7,8 @@ A class to wrap and extend the Property object implemented in JSBSim
 
 '''
 
-Property = namedtuple('Property', ['name_jsbsim', 'description', 'min', 'max', 'access', 'spaces', 'update'])
+Property = namedtuple('Property', 'name_jsbsim description min max access spaces clipped update')
+Property.__new__.__defaults__ = (None, None, float('-inf'), float('+inf'), 'RW', Box, True, None)
 
-Property.__new__.__defaults__ = ( None, float('-inf'), float('+inf'),'RW', Box, None)
+CustomProperty = namedtuple('CustomProperty', 'name_jsbsim description min max access spaces clipped read write')
+CustomProperty.__new__.__defaults__ = (None, None, float('-inf'), float('+inf'), 'RW', Box, False, None, None)

--- a/gym_jsbsim/jsbsim_env.py
+++ b/gym_jsbsim/jsbsim_env.py
@@ -138,7 +138,7 @@ class JSBSimEnv(gym.Env):
 
         return is_not_contained or self.task.is_terminal(self.state, self.sim)
 
-    def render(self, mode='human'):
+    def render(self, mode='human', **kwargs):
         """Renders the environment.
 
         The set of supported modes varies per environment. (And some
@@ -162,7 +162,8 @@ class JSBSimEnv(gym.Env):
 
         :param mode: str, the mode to render with
         """
-        output = self.task.get_output()
+        self.task.render(self.sim, mode=mode, **kwargs)
+        """output = self.task.get_output()
 
         if mode == 'human':
             pass
@@ -170,6 +171,7 @@ class JSBSimEnv(gym.Env):
             pass
         else:
             pass
+        """
 
     def seed(self, seed=None):
         """

--- a/gym_jsbsim/jsbsim_env.py
+++ b/gym_jsbsim/jsbsim_env.py
@@ -220,27 +220,21 @@ class JSBSimEnv(gym.Env):
 
         """
         obs_list = self.sim.get_property_values(self.task.get_observation_var())
-        obs_tuple = ()
-        for obs in obs_list:
-            obs_tuple += (np.array([obs]),)
-        return obs_tuple
+        return tuple([np.array([obs]) for obs in obs_list])
 
     def get_sim_time(self):
         """ Gets the simulation time from sim, a float. """
-
         return self.sim.get_sim_time()
 
     def get_state(self):
         return self.sim.get_sim_state()
 
     def _get_clipped_state(self):
-        clipped_state = np.clip(self.state,
-                                [o.low for o in self.observation_space],
-                                [o.high for o in self.observation_space])
-        # Shape the state as a tuple of arrays
-        clipped_state = tuple(np.array([val]) for val in clipped_state.squeeze())
-
-        return clipped_state
+        clipped = [
+            np.clip(self.state[i], o.low, o.high) if self.task.state_var[i].clipped else self.state[i]
+            for i, o in enumerate(self.observation_space)
+        ]
+        return tuple(clipped)
 
     def set_state(self, state):
         self.sim.set_sim_state(state)

--- a/gym_jsbsim/task.py
+++ b/gym_jsbsim/task.py
@@ -84,6 +84,9 @@ class Task:
                 space_tuple += (Discrete(prop.max - prop.min + 1),)
         return gym.spaces.Tuple(space_tuple)
 
+    def render(self, sim, mode='human', **kwargs):
+        pass
+
     def define_aircraft(self, aircraft_name='A320'):
         self.aircraft_name = aircraft_name
 


### PR DESCRIPTION
These properties are not stored inside jsbsim simulation. This is needed for properties that are not scalar values (eg. np.array) because JSBSim simulation only support scalars.

I also added a Task.render(...) method which is called whenever JSBSimEnv.render(...) is called. 