### PR TITLE
env.render() now return the result of task.render()

### DIFF
--- a/gym_jsbsim/jsbsim_env.py
+++ b/gym_jsbsim/jsbsim_env.py
@@ -162,16 +162,7 @@ class JSBSimEnv(gym.Env):
 
         :param mode: str, the mode to render with
         """
-        self.task.render(self.sim, mode=mode, **kwargs)
-        """output = self.task.get_output()
-
-        if mode == 'human':
-            pass
-        elif mode == 'csv':
-            pass
-        else:
-            pass
-        """
+        return self.task.render(self.sim, mode=mode, **kwargs)
 
     def seed(self, seed=None):
         """


### PR DESCRIPTION
This allows to handle the rendering of an episode outside of the Task class